### PR TITLE
Fix code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/main.cjs
+++ b/main.cjs
@@ -8,6 +8,7 @@ const JS7z = require("./libraries/js7z/js7z.cjs");
 const crypto = require("crypto");
 
 const express = require("express");
+const RateLimit = require("express-rate-limit");
 const DEFAULT_PORT = 8998;
 const MIN_PORT = 1024; // Minimum valid port number
 const MAX_PORT = 65535; // Maximum valid port number
@@ -313,6 +314,15 @@ function createWindow() {
 
     applog.info(`App started. Version ${version}`);
 }
+
+// Set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = RateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+});
+
+// Apply rate limiter to all requests
+expressApp.use(limiter);
 
 // Set up the express server to serve video files
 expressApp.get("/video/:folderName/:fileName", (req, res) => {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
         "react-loading-skeleton": "^3.5.0",
         "react-router-dom": "^7.1.1",
         "sonner": "^1.7.1",
-        "wavesurfer.js": "^7.8.15"
+        "wavesurfer.js": "^7.8.15",
+        "express-rate-limit": "^7.5.0"
     },
     "devDependencies": {
         "@electron-forge/cli": "^7.6.0",


### PR DESCRIPTION
Fixes [https://github.com/yllst-testing-labs/ispeakerreact/security/code-scanning/2](https://github.com/yllst-testing-labs/ispeakerreact/security/code-scanning/2)

To fix the problem, we need to introduce rate limiting to the Express application to prevent abuse and potential denial-of-service attacks. The best way to achieve this is by using the `express-rate-limit` package, which allows us to set a maximum number of requests that can be made to the server within a specified time window.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the main.cjs file.
3. Set up a rate limiter with appropriate configuration (e.g., maximum of 100 requests per 15 minutes).
4. Apply the rate limiter to the Express application.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
