### PR TITLE
Add error notification in app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ispeakerreact",
-    "version": "3.2.10",
+    "version": "3.2.12",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ispeakerreact",
-            "version": "3.2.10",
+            "version": "3.2.12",
             "license": "Apache-2.0",
             "dependencies": {
                 "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "author": "yell0wsuit",
     "description": "An English-learning interactive tool written in React, designed to help learners practice speaking and listening",
     "private": true,
-    "version": "3.2.11",
+    "version": "3.2.12",
     "type": "module",
     "main": "main.cjs",
     "license": "Apache-2.0",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -31,6 +31,13 @@
         "appUpdateError": "Error checking for updates. Please try again.",
         "rateLimited": "Cannot check for new version due to rate limiting. Please try again after {{time}}."
     },
+    "appCrash": {
+        "appCrashedTitle": "App crashed!",
+        "appCrashedDesc": "Please copy the error below and report it in a GitHub issue.",
+        "copyBtn": "Copy error log",
+        "openGitHubBtn": "Open GitHub issue",
+        "refreshBtn": "Refresh page"
+    },
     "toast": {
         "recordingExceeded": "Duration limit reached. Recording has stopped.",
         "recordingSuccess": "Recording saved successfully",
@@ -43,7 +50,8 @@
         "audioPlayFailed": "Unable to play audio due to a network issue. Please check your connection and reload the page.",
         "loadingError": "Error while loading the data. Please try refreshing the page.",
         "reviewUpdated": "Review updated successfully",
-        "noRecording": "Please record first before reviewing"
+        "noRecording": "Please record first before reviewing",
+        "appCrashCopySuccess": "Error log copied to clipboard"
     },
     "buttonConversationExam": {
         "watchBtn": "Watch",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import { Toaster } from "sonner";
 import LoadingOverlay from "./components/general/LoadingOverlay";
 import NotFound from "./components/general/NotFound";
 import Homepage from "./components/Homepage";
+import ErrorBoundary from "./ErrorBoundary";
 import { isElectron } from "./utils/isElectron";
 import { ThemeProvider } from "./utils/ThemeContext/ThemeProvider";
 import { useTheme } from "./utils/ThemeContext/useTheme";
@@ -196,9 +197,11 @@ const AppContent = () => {
 };
 
 const App = () => (
-    <ThemeProvider>
-        <AppContent />
-    </ThemeProvider>
+    <ErrorBoundary>
+        <ThemeProvider>
+            <AppContent />
+        </ThemeProvider>
+    </ErrorBoundary>
 );
 
 export default App;

--- a/src/ErrorBoundary.jsx
+++ b/src/ErrorBoundary.jsx
@@ -1,0 +1,10 @@
+import { useTranslation } from "react-i18next";
+import ErrorBoundaryInner from "./ErrorBoundaryInner";
+
+const ErrorBoundary = (props) => {
+    const { t } = useTranslation();
+
+    return <ErrorBoundaryInner {...props} t={t} />;
+};
+
+export default ErrorBoundary;

--- a/src/ErrorBoundaryInner.jsx
+++ b/src/ErrorBoundaryInner.jsx
@@ -32,11 +32,12 @@ export default class ErrorBoundary extends React.Component {
 
     handleCopy = () => {
         const { error, errorInfo } = this.state;
-        const fullError = `
+        const fullError = `Error log:\n
 \`\`\`
-${error?.toString()}\n\nStack Trace:\n${errorInfo?.componentStack}
+${error?.toString()}\nApp version: v${__APP_VERSION__}\n\nStack Trace:\n${errorInfo?.componentStack}
 \`\`\`
 `;
+
         navigator.clipboard.writeText(fullError).then(() => {
             sonnerSuccessToast(this.props.t("toast.appCrashCopySuccess"));
         });
@@ -51,22 +52,24 @@ ${error?.toString()}\n\nStack Trace:\n${errorInfo?.componentStack}
         if (hasError) {
             return (
                 <Container>
-                    <div className="grid min-h-screen place-items-center">
-                        <div className="rounded-lg bg-red-50 p-6 text-red-700 dark:bg-red-300 dark:text-black">
+                    <div className="flex min-h-screen flex-row items-center justify-center">
+                        <div className="w-full rounded-lg bg-red-50 p-6 text-red-700 dark:bg-red-300 dark:text-black">
                             <h2 className="mb-4 text-2xl font-bold">
                                 🚨 {t("appCrash.appCrashedTitle")}
                             </h2>
                             <p className="mb-4">{t("appCrash.appCrashedDesc")}</p>
-                            <div className="card bg-base-100 card-md max-h-64 overflow-auto p-4 font-mono text-sm whitespace-pre-wrap shadow-sm">
+                            <div className="card bg-base-100 card-md max-h-100 overflow-auto whitespace-pre-wrap shadow-sm lg:max-h-64">
                                 <div className="card-body">
                                     <code className="font-mono! dark:text-red-200">
                                         {error?.toString()}
+                                        {"\n"}
+                                        App version: v{__APP_VERSION__}
                                         {"\n"}
                                         {errorInfo?.componentStack}
                                     </code>
                                 </div>
                             </div>
-                            <div className="my-6 flex flex-wrap justify-center gap-2 px-8">
+                            <div className="my-6 flex flex-wrap justify-center gap-2">
                                 <button onClick={this.handleCopy} className="btn btn-primary">
                                     <HiOutlineClipboardCopy className="h-5 w-5" />
                                     {t("appCrash.copyBtn")}

--- a/src/ErrorBoundaryInner.jsx
+++ b/src/ErrorBoundaryInner.jsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { FaGithub } from "react-icons/fa";
+import { FiRefreshCw } from "react-icons/fi";
+import { HiOutlineClipboardCopy } from "react-icons/hi";
+import { Toaster } from "sonner";
+import Container from "./ui/Container";
+import { isElectron } from "./utils/isElectron";
+import { sonnerSuccessToast } from "./utils/sonnerCustomToast";
+
+const handleOpenExternal = (url) => {
+    if (isElectron()) {
+        window.electron.openExternal(url);
+    } else {
+        window.open(url, "_blank", "noopener,noreferrer");
+    }
+};
+
+export default class ErrorBoundary extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = { hasError: false, error: null, errorInfo: null };
+    }
+
+    static getDerivedStateFromError(error) {
+        return { hasError: true, error };
+    }
+
+    componentDidCatch(error, errorInfo) {
+        console.error("React Error Boundary caught an error:", error, errorInfo);
+        this.setState({ errorInfo });
+    }
+
+    handleCopy = () => {
+        const { error, errorInfo } = this.state;
+        const fullError = `
+\`\`\`
+${error?.toString()}\n\nStack Trace:\n${errorInfo?.componentStack}
+\`\`\`
+`;
+        navigator.clipboard.writeText(fullError).then(() => {
+            sonnerSuccessToast(this.props.t("toast.appCrashCopySuccess"));
+        });
+    };
+
+    handleRefresh = () => location.reload();
+
+    render() {
+        const { hasError, error, errorInfo } = this.state;
+        const { t } = this.props;
+
+        if (hasError) {
+            return (
+                <Container>
+                    <div className="grid min-h-screen place-items-center">
+                        <div className="rounded-lg bg-red-50 p-6 text-red-700 dark:bg-red-300 dark:text-black">
+                            <h2 className="mb-4 text-2xl font-bold">
+                                🚨 {t("appCrash.appCrashedTitle")}
+                            </h2>
+                            <p className="mb-4">{t("appCrash.appCrashedDesc")}</p>
+                            <div className="card bg-base-100 card-md max-h-64 overflow-auto p-4 font-mono text-sm whitespace-pre-wrap shadow-sm">
+                                <div className="card-body">
+                                    <code className="font-mono! dark:text-red-200">
+                                        {error?.toString()}
+                                        {"\n"}
+                                        {errorInfo?.componentStack}
+                                    </code>
+                                </div>
+                            </div>
+                            <div className="my-6 flex flex-wrap justify-center gap-2 px-8">
+                                <button onClick={this.handleCopy} className="btn btn-primary">
+                                    <HiOutlineClipboardCopy className="h-5 w-5" />
+                                    {t("appCrash.copyBtn")}
+                                </button>
+                                <button
+                                    onClick={() =>
+                                        handleOpenExternal(
+                                            "https://github.com/yllst-testing-labs/ispeakerreact/issues"
+                                        )
+                                    }
+                                    className="btn btn-info"
+                                >
+                                    <FaGithub className="h-5 w-5" />
+                                    {t("appCrash.openGitHubBtn")}
+                                </button>
+                                <button onClick={this.handleRefresh} className="btn btn-secondary">
+                                    <FiRefreshCw className="h-5 w-5" />
+                                    {t("appCrash.refreshBtn")}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                    <Toaster
+                        className="flex justify-center"
+                        position="bottom-center"
+                        duration="7000"
+                    />
+                </Container>
+            );
+        }
+
+        return this.props.children;
+    }
+}

--- a/src/components/general/Footer.jsx
+++ b/src/components/general/Footer.jsx
@@ -5,11 +5,7 @@ const openExternal = (url) => {
     if (isElectron()) {
         window.electron.openExternal(url);
     } else {
-        const link = document.createElement("a");
-        link.href = url;
-        link.target = "_blank";
-        link.rel = "noopener noreferrer";
-        link.click();
+        window.open(url, "_blank", "noopener,noreferrer");
     }
 };
 

--- a/src/components/general/TopNavBar.jsx
+++ b/src/components/general/TopNavBar.jsx
@@ -16,11 +16,7 @@ const openExternal = (url) => {
     if (isElectron()) {
         window.electron.openExternal(url);
     } else {
-        const link = document.createElement("a");
-        link.href = url;
-        link.target = "_blank";
-        link.rel = "noopener noreferrer";
-        link.click();
+        window.open(url, "_blank", "noopener,noreferrer");
     }
 };
 


### PR DESCRIPTION
![App crash UI image](https://github.com/user-attachments/assets/22639767-3212-4112-8e28-d01453f17191)


Adds a detailed error boundary UI to help users report issues.
When the app crashes, users will now see a detailed error log with a copy button and a direct link to GitHub issues. This helps us pinpoint problems more accurately and improves the debugging process.