### PR TITLE
Create the video download folder if not exist, add workflow for populating download links

### DIFF
--- a/.github/workflows/releasebody.yaml
+++ b/.github/workflows/releasebody.yaml
@@ -1,0 +1,46 @@
+name: Update Release Description
+
+on:
+    release:
+        types: [published]
+
+    # Allows you to run this workflow manually from the Actions tab
+    workflow_dispatch:
+
+jobs:
+    update-release:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@main
+
+            - name: Set up Python
+              uses: actions/setup-python@main
+              with:
+                  python-version: "3.13"
+
+            - name: Install dependencies
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install requests
+
+            - name: Generate release markdown
+              run: |
+                  python scripts/gh_releases_body.py > release_body.md
+
+            - name: Update release
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  RELEASE_ID: ${{ github.event.release.id }}
+              run: |
+                  curl -X PATCH \
+                    -H "Authorization: token $GITHUB_TOKEN" \
+                    -H "Accept: application/vnd.github.v3+json" \
+                    https://api.github.com/repos/${{ github.repository }}/releases/$RELEASE_ID \
+                    -d @- << EOF
+                  {
+                    "body": $(cat release_body.md | jq -R -s '.')
+                  }
+                  EOF

--- a/main.cjs
+++ b/main.cjs
@@ -432,6 +432,11 @@ ipcMain.handle("play-recording", async (event, key) => {
 ipcMain.handle("check-downloads", () => {
     const saveFolder = getSaveFolder();
     const videoFolder = path.join(saveFolder, "video_files");
+    // Ensure the directory exists
+    if (!fs.existsSync(videoFolder)) {
+        fs.mkdirSync(videoFolder, { recursive: true });
+    }
+
     const files = fs.readdirSync(videoFolder);
     // Return the list of zip files in the download folder
     return files.filter((file) => file.endsWith(".7z"));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ispeakerreact",
-    "version": "3.2.12",
+    "version": "3.2.13",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ispeakerreact",
-            "version": "3.2.12",
+            "version": "3.2.13",
             "license": "Apache-2.0",
             "dependencies": {
                 "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "author": "yell0wsuit",
     "description": "An English-learning interactive tool written in React, designed to help learners practice speaking and listening",
     "private": true,
-    "version": "3.2.12",
+    "version": "3.2.13",
     "type": "module",
     "main": "main.cjs",
     "license": "Apache-2.0",

--- a/scripts/gh_releases_body.py
+++ b/scripts/gh_releases_body.py
@@ -1,0 +1,91 @@
+import requests
+import os
+
+# Get info from the environment
+repo = os.environ.get("GITHUB_REPOSITORY", "yllst-testing-labs/ispeakerreact")
+release_id = os.environ.get("RELEASE_ID")
+
+# Define the GitHub API URL and headers
+url = f"https://api.github.com/repos/{repo}/releases/{release_id}"
+token = os.environ.get("GITHUB_TOKEN")
+headers = {
+    "User-Agent": "yllst-testing-labs-release-updater-action",
+    "Authorization": f"token {token}",
+    "Accept": "application/vnd.github.v3+json",
+}
+
+# Fetch the release data
+response = requests.get(url, headers=headers)
+release_data = response.json()
+
+# Extract necessary details
+tag = release_data["tag_name"]
+name = release_data["name"]
+assets = release_data["assets"]
+changelog_url = f"https://github.com/{repo}/compare/{tag.split('-')[0]}...{tag}"
+
+# Organize assets by platform
+windows_downloads = []
+macos_downloads = []
+linux_downloads = []
+
+# First, collect all Windows downloads
+for asset in assets:
+    asset_name = asset["name"]
+    download_url = asset["browser_download_url"]
+    if "win32" in asset_name:
+        is_portable = "Setup.exe" not in asset_name
+        is_arm64 = "arm64" in asset_name
+
+        # Create tuple for sorting: (is_portable, is_arm64, label, url)
+        if is_portable:
+            label = "Portable version"
+            if is_arm64:
+                label += " for Windows ARM"
+            windows_downloads.append((True, is_arm64, label, download_url))
+        else:
+            label = "Installer version"
+            if is_arm64:
+                label += " for Windows ARM"
+            windows_downloads.append((False, is_arm64, label, download_url))
+    elif asset_name.endswith(".dmg"):
+        if "arm64" in asset_name:
+            label = "For Mac with Apple Silicon chip"
+        else:
+            label = "For Mac with Intel chip"
+        macos_downloads.append(f"- [{label}]({download_url})")
+    elif (
+        asset_name.endswith(".zip")
+        or asset_name.endswith(".deb")
+        or asset_name.endswith(".rpm")
+    ):
+        linux_downloads.append(f"- [{asset_name}]({download_url})")
+
+# Sort Windows downloads: portable first, then x64 before arm64
+windows_downloads.sort(key=lambda x: (not x[0], x[1]))
+windows_formatted = [f"- [{item[2]}]({item[3]})" for item in windows_downloads]
+
+# Build markdown
+markdown = f"""## Download
+
+### Windows
+{"\n".join(windows_formatted)}
+
+This app requires Windows 10 or later.
+
+### macOS
+{"\n".join(macos_downloads)}
+
+### Linux
+{"\n".join(linux_downloads)}
+
+There is no AppImage version for this app yet.
+
+## App updates
+
+/* Please add some here manually */
+
+**Full Changelog**: {changelog_url}
+"""
+
+print(markdown.strip())

--- a/src/components/setting_page/VideoDownloadSubPage.jsx
+++ b/src/components/setting_page/VideoDownloadSubPage.jsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { BsArrowLeft } from "react-icons/bs";
 import { IoWarningOutline } from "react-icons/io5";
+import { isElectron } from "../../utils/isElectron";
 import VideoDownloadTable from "./VideoDownloadTable";
 
 const VideoDownloadSubPage = ({ onGoBack }) => {
@@ -25,6 +26,7 @@ const VideoDownloadSubPage = ({ onGoBack }) => {
                 setZipFileData(data); // Set the JSON data into the state
             } catch (error) {
                 console.error("Error reading JSON file:", error); // Handle any error
+                isElectron() && window.electron.log("error", `Error reading JSON file: ${error}`);
             }
         };
 
@@ -35,6 +37,8 @@ const VideoDownloadSubPage = ({ onGoBack }) => {
         try {
             const downloadedFiles = await window.electron.ipcRenderer.invoke("check-downloads");
             console.log("Downloaded files in folder:", downloadedFiles);
+            isElectron() &&
+                window.electron.log("log", `Downloaded files in folder: ${downloadedFiles}`);
 
             // Initialize fileStatus as an array to hold individual statuses
             const newFileStatus = [];
@@ -49,6 +53,11 @@ const VideoDownloadSubPage = ({ onGoBack }) => {
                     );
                 } catch (error) {
                     console.error(`Error checking extracted folder for ${item.zipFile}:`, error);
+                    isElectron() &&
+                        window.electron.log(
+                            "error",
+                            `Error checking extracted folder for ${item.zipFile}: ${error}`
+                        );
                     extractedFolderExists = false; // Default to false if there's an error
                 }
 
@@ -65,6 +74,11 @@ const VideoDownloadSubPage = ({ onGoBack }) => {
             console.log(newFileStatus);
         } catch (error) {
             console.error("Error checking downloaded or extracted files:", error);
+            isElectron() &&
+                window.electron.log(
+                    "error",
+                    `Error checking downloaded or extracted files: ${error}`
+                );
         }
     }, [zipFileData]);
 


### PR DESCRIPTION
_Originally posted by @justqiang118 in https://github.com/yllst-testing-labs/ispeakerreact/discussions/34#discussioncomment-12640865_

Clicking the "Download video files" button in the Settings section caused the app to crash if the `video_files` folder did not already exist.

Solution:
Added a check to ensure the `video_files` folder is created if it doesn't exist. This prevents the app from crashing due to a missing directory.

Misc: Add workflow for populating download links