### PR TITLE
fix: Video verification fixes; chore: use js7z from npm

### DIFF
--- a/main.cjs
+++ b/main.cjs
@@ -4,7 +4,7 @@ const path = require("path");
 const net = require("net");
 const isDev = process.env.NODE_ENV === "development";
 const fs = require("fs");
-const JS7z = require("./libraries/js7z/js7z.cjs");
+const JS7z = require("js7z-tools");
 const crypto = require("crypto");
 
 const express = require("express");

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
                 "i18next": "^25.0.2",
                 "i18next-browser-languagedetector": "^8.0.5",
                 "i18next-http-backend": "^3.0.2",
+                "js7z-tools": "^2.4.1",
                 "lodash": "^4.17.21",
                 "masonry-layout": "^4.2.2",
                 "mime": "^4.0.7",
@@ -9647,6 +9648,12 @@
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
             }
+        },
+        "node_modules/js7z-tools": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/js7z-tools/-/js7z-tools-2.4.1.tgz",
+            "integrity": "sha512-qnBnbxDN9ARL8r2E/KmK2c/RwxfDpZn2mRA+l2CeFC/7GrWwuQqP0Y/ONgXsnylMp/5Z1RdiyIQtdayalz979g==",
+            "license": "SEE LICENSE IN 7z-Src/DOC"
         },
         "node_modules/jsbn": {
             "version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ispeakerreact",
-    "version": "3.3.2",
+    "version": "3.3.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ispeakerreact",
-            "version": "3.3.2",
+            "version": "3.3.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "author": "yell0wsuit",
     "description": "An English-learning interactive tool written in React, designed to help learners practice speaking and listening",
     "private": true,
-    "version": "3.3.2",
+    "version": "3.3.3",
     "type": "module",
     "main": "main.cjs",
     "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "i18next": "^25.0.2",
         "i18next-browser-languagedetector": "^8.0.5",
         "i18next-http-backend": "^3.0.2",
+        "js7z-tools": "^2.4.1",
         "lodash": "^4.17.21",
         "masonry-layout": "^4.2.2",
         "mime": "^4.0.7",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1255,6 +1255,8 @@
             "verifySuccessMessage": "All extracted files are verified in the folder:",
             "verifyFailed": "Verification failed",
             "verifyFailedMessage": "It seems like either the files are corrupted or missing. Please try downloading the file again.",
+            "fileMissing": "These files are missing:",
+            "hashMismatch": "These files have hash mismatch. They could be corrupted or tampered.",
             "electronVerifyMessage": {
                 "extractedSuccessMsg": "All extracted files are verified for",
                 "zipSuccessMsg": "Successfully verified and extracted",

--- a/src/components/setting_page/VideoDownloadSubPage.jsx
+++ b/src/components/setting_page/VideoDownloadSubPage.jsx
@@ -150,7 +150,7 @@ const VideoDownloadSubPage = ({ onGoBack }) => {
                 </button>
             </div>
 
-            <VideoDownloadTable data={zipFileData} isDownloaded={isDownloaded} t={t} />
+            <VideoDownloadTable data={zipFileData} isDownloaded={isDownloaded} t={t} onStatusChange={checkDownloadedFiles} />
         </div>
     );
 };

--- a/src/components/setting_page/VideoDownloadTable.jsx
+++ b/src/components/setting_page/VideoDownloadTable.jsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import { Trans } from "react-i18next";
 import { BsCheckCircleFill, BsXCircleFill } from "react-icons/bs";
 
-const VideoDownloadTable = ({ t, data, isDownloaded }) => {
+const VideoDownloadTable = ({ t, data, isDownloaded, onStatusChange }) => {
     const [, setShowVerifyModal] = useState(false);
     const [showProgressModal, setShowProgressModal] = useState(false);
     const [selectedZip, setSelectedZip] = useState(null);
@@ -13,6 +13,7 @@ const VideoDownloadTable = ({ t, data, isDownloaded }) => {
     const [isSuccess, setIsSuccess] = useState(null);
     const [progressText, setProgressText] = useState("");
     const [isPercentage, setIsPercentage] = useState(false);
+    const [progressError, setProgressError] = useState(false);
 
     const verifyModal = useRef(null);
     const progressModal = useRef(null);
@@ -40,6 +41,7 @@ const VideoDownloadTable = ({ t, data, isDownloaded }) => {
             );
             setIsSuccess(true);
             setShowProgressModal(false); // Hide modal after success
+            if (onStatusChange) onStatusChange(); // Trigger parent to refresh status
         };
 
         const handleVerificationError = (event, data) => {
@@ -53,6 +55,7 @@ const VideoDownloadTable = ({ t, data, isDownloaded }) => {
             );
             setIsSuccess(false);
             setShowProgressModal(false); // Hide modal on error
+            if (onStatusChange) onStatusChange(); // Trigger parent to refresh status
         };
 
         window.electron.ipcRenderer.on("progress-update", handleProgressUpdate);
@@ -66,19 +69,50 @@ const VideoDownloadTable = ({ t, data, isDownloaded }) => {
             window.electron.ipcRenderer.removeAllListeners("verification-success");
             window.electron.ipcRenderer.removeAllListeners("verification-error");
         };
-    }, [t, data.messageKey, data.param]);
+    }, [t, data.messageKey, data.param, onStatusChange]);
 
-    const handleVerify = (zip) => {
+    const handleVerify = async (zip) => {
+        if (onStatusChange) {
+            // Await refresh if onStatusChange returns a promise
+            await onStatusChange();
+        }
+        // Find the latest file status after refresh
+        const fileStatus = isDownloaded.find((status) => status.zipFile === zip.zipFile);
+        const fileToVerify =
+            fileStatus && zip.name && (fileStatus.isDownloaded || fileStatus.hasExtractedFolder)
+                ? [{ name: zip.name }]
+                : [];
         setSelectedZip(zip);
-        const fileToVerify = zip.name ? [{ name: zip.name }] : [];
         setVerifyFiles(fileToVerify);
         setShowVerifyModal(true);
         verifyModal.current?.showModal();
     };
 
-    const handleNextModal = () => {
+    const handleNextModal = async () => {
+        if (onStatusChange) {
+            await onStatusChange();
+        }
+        const fileStatus = isDownloaded.find((status) => status.zipFile === selectedZip?.zipFile);
+        const fileToVerify =
+            fileStatus &&
+            selectedZip?.name &&
+            (fileStatus.isDownloaded || fileStatus.hasExtractedFolder)
+                ? [{ name: selectedZip.name }]
+                : [];
+        if (fileToVerify.length === 0) {
+            setShowVerifyModal(false);
+            setShowProgressModal(false);
+            setIsSuccess(false);
+            setProgressError(true);
+            setProgressText("");
+            setModalMessage(t("settingPage.videoDownloadSettings.verifyFailedMessage"));
+            progressModal.current?.showModal();
+            verifyModal.current?.close();
+            return;
+        }
         setShowVerifyModal(false);
         setShowProgressModal(true);
+        setProgressError(false);
         setProgressText(t("settingPage.videoDownloadSettings.verifyinProgressMsg"));
         window.electron.ipcRenderer.send("verify-and-extract", selectedZip);
         progressModal.current?.showModal();
@@ -164,7 +198,7 @@ const VideoDownloadTable = ({ t, data, isDownloaded }) => {
                                         <button
                                             type="button"
                                             className="btn btn-accent btn-sm"
-                                            onClick={() => handleVerify(item)}
+                                            onClick={async () => await handleVerify(item)}
                                             disabled={
                                                 !fileStatus ||
                                                 (!fileStatus.isDownloaded &&
@@ -216,10 +250,7 @@ const VideoDownloadTable = ({ t, data, isDownloaded }) => {
                                 </p>
                             </>
                         ) : (
-                            <p>
-                                Either you haven’t downloaded the file(s) yet, or the filename does
-                                not match.
-                            </p>
+                            <p>{t("settingPage.videoDownloadSettings.verifyFailedMessage")}</p>
                         )}
                     </div>
                     <div className="modal-action">
@@ -228,7 +259,7 @@ const VideoDownloadTable = ({ t, data, isDownloaded }) => {
                         </button>
                         <button
                             className="btn btn-primary"
-                            onClick={handleNextModal}
+                            onClick={async () => await handleNextModal()}
                             disabled={verifyFiles.length === 0}
                         >
                             {t("settingPage.videoDownloadSettings.nextBtn")}
@@ -247,7 +278,7 @@ const VideoDownloadTable = ({ t, data, isDownloaded }) => {
                               : t("settingPage.videoDownloadSettings.verifyFailed")}
                     </h3>
                     <div className="py-4">
-                        {showProgressModal === true ? (
+                        {showProgressModal === true && !progressError ? (
                             <>
                                 <p>{progressText}</p>
                                 <progress
@@ -266,7 +297,7 @@ const VideoDownloadTable = ({ t, data, isDownloaded }) => {
                         <button
                             className="btn"
                             onClick={handleCloseProgressModal}
-                            disabled={showProgressModal === true}
+                            disabled={showProgressModal === true && !progressError}
                         >
                             {t("sound_page.closeBtn")}
                         </button>
@@ -281,6 +312,7 @@ VideoDownloadTable.propTypes = {
     t: PropTypes.func.isRequired,
     data: PropTypes.array.isRequired,
     isDownloaded: PropTypes.array.isRequired,
+    onStatusChange: PropTypes.func,
 };
 
 export default VideoDownloadTable;


### PR DESCRIPTION
- fix: prevent softlock when users delete the downloaded file externally, then proceed to verify.
- fix: more robust, clearer error messages.
- chore: use js7z from npm